### PR TITLE
Api reorganization

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,12 @@ import { Router } from "@reach/router";
 import "./App.sass";
 
 import axiosInstance from "./axiosAPI";
+import {
+  userDataEndpoint,
+  medicalLiabilityEndpoint,
+  liabilityWaiverEndpoint,
+  studentAvailabilityEndpoint,
+} from "./apiEndpoints";
 
 import Nav from "./layout/Nav";
 import Footer from "./layout/Footer";
@@ -59,7 +65,7 @@ class App extends Component<{}, State> {
 
   componentDidMount() {
     if (this.state.loggedIn) {
-      axiosInstance.get("/current_user/").then(result => {
+      axiosInstance.get(userDataEndpoint).then(result => {
         this.setState({
           username: result.data.username,
           isStudent: result.data.is_student,
@@ -136,19 +142,19 @@ class App extends Component<{}, State> {
             <DummyForm
               path="/:program/:edition/medliab"
               isStudent={this.state.isStudent}
-              url="medliab"
+              url={medicalLiabilityEndpoint}
               formName="Medical Liabilility Form"
             />
             <DummyForm
               path="/:program/:edition/waiver"
               isStudent={this.state.isStudent}
-              url="waiver"
+              url={liabilityWaiverEndpoint}
               formName="Liability Waiver Form"
             />
             <DummyForm
               path="/:program/:edition/availability"
               isStudent={this.state.isStudent}
-              url="availability"
+              url={studentAvailabilityEndpoint}
               formName="Program Availability"
             />
             <ChangeClassesDashboard

--- a/client/src/accounts/LoginForm.tsx
+++ b/client/src/accounts/LoginForm.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import axiosInstance from "../axiosAPI";
 import { renderLabeledInput } from "../forms/helpers";
+import { loginEndpoint } from "../apiEndpoints";
 
 type LoginProps = {
   onLogin: Function;
@@ -39,7 +40,7 @@ class LoginForm extends Component<LoginProps, LoginState> {
   handleLogin = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     axiosInstance
-      .post("/token/", {
+      .post(loginEndpoint, {
         username: this.state.username,
         password: this.state.password,
       })

--- a/client/src/accounts/StudentSignupForm.tsx
+++ b/client/src/accounts/StudentSignupForm.tsx
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import axiosInstance from "../axiosAPI";
 import { navigate } from "@reach/router";
 import { renderLabeledInput } from "../forms/helpers";
+import { studentSignupEndpoint } from "../apiEndpoints";
 
 type Props = {
   onLogin: Function;
@@ -46,7 +47,7 @@ class StudentSignupForm extends Component<Props, State> {
   handleSignup = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     axiosInstance
-      .post("/add_student/", {
+      .post(studentSignupEndpoint, {
         username: this.state.username,
         password: this.state.password,
         profile: {

--- a/client/src/apiEndpoints.ts
+++ b/client/src/apiEndpoints.ts
@@ -1,20 +1,22 @@
 // Accounts
 const loginEndpoint = "/token/";
 const tokenRefreshEndpoint = "/token/refresh/";
-const userDataEndpoint = "/current_user/";
-const signupEndpoint = "/add_user/";
+const userDataEndpoint = "/user/";
+const signupEndpoint = "/account/";
+
+// Profile
+const studentProfileEndpoint = "/profile/student/";
 
 // Dashboards
-const studentDashboardEndpoint = "/studentdashboard/";
-const teacherDashboardEndpoint = "/teacherprograms/";
+const studentDashboardEndpoint = "/dashboard/student/";
+const teacherDashboardEndpoint = "/dashboard/teacher/";
 
-// studentreg
-const studentRegEndpoint = "/current_studentreg/";
-const emergencyInfoEndpoint = "/emergency_info/";
-const studentProfileEndpoint = "/profile/";
-const medicalLiabilityEndpoint = "/medliab/";
-const liabilityWaiverEndpoint = "/waiver/";
-const studentAvailabilityEndpoint = "/availability/";
+// studentreg (these requires /program/edition/ before)
+const studentRegEndpoint = "student/";
+const emergencyInfoEndpoint = "student/emergency_info/";
+const medicalLiabilityEndpoint = "student/medliab/";
+const liabilityWaiverEndpoint = "student/waiver/";
+const studentAvailabilityEndpoint = "student/availability/";
 
 export {
   loginEndpoint,

--- a/client/src/apiEndpoints.ts
+++ b/client/src/apiEndpoints.ts
@@ -1,0 +1,32 @@
+// Accounts
+const loginEndpoint = "/token/";
+const tokenRefreshEndpoint = "/token/refresh/";
+const userDataEndpoint = "/current_user/";
+const signupEndpoint = "/add_user/";
+
+// Dashboards
+const studentDashboardEndpoint = "/studentdashboard/";
+const teacherDashboardEndpoint = "/teacherprograms/";
+
+// studentreg
+const studentRegEndpoint = "/current_studentreg/";
+const emergencyInfoEndpoint = "/emergency_info/";
+const studentProfileEndpoint = "/profile/";
+const medicalLiabilityEndpoint = "/medliab/";
+const liabilityWaiverEndpoint = "/waiver/";
+const studentAvailabilityEndpoint = "/availability/";
+
+export {
+  loginEndpoint,
+  tokenRefreshEndpoint,
+  userDataEndpoint,
+  signupEndpoint,
+  studentDashboardEndpoint,
+  teacherDashboardEndpoint,
+  studentRegEndpoint,
+  emergencyInfoEndpoint,
+  studentProfileEndpoint,
+  medicalLiabilityEndpoint,
+  liabilityWaiverEndpoint,
+  studentAvailabilityEndpoint,
+};

--- a/client/src/apiEndpoints.ts
+++ b/client/src/apiEndpoints.ts
@@ -2,7 +2,7 @@
 const loginEndpoint = "/token/";
 const tokenRefreshEndpoint = "/token/refresh/";
 const userDataEndpoint = "/user/";
-const signupEndpoint = "/account/";
+const studentSignupEndpoint = "/account/student/";
 
 // Profile
 const studentProfileEndpoint = "/profile/student/";
@@ -22,7 +22,7 @@ export {
   loginEndpoint,
   tokenRefreshEndpoint,
   userDataEndpoint,
-  signupEndpoint,
+  studentSignupEndpoint,
   studentDashboardEndpoint,
   teacherDashboardEndpoint,
   studentRegEndpoint,

--- a/client/src/axiosAPI.tsx
+++ b/client/src/axiosAPI.tsx
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { tokenRefreshEndpoint } from "./apiEndpoints";
 
 const axiosInstance = axios.create({
   baseURL: "http://localhost:8000/api/",
@@ -27,7 +28,7 @@ axiosInstance.interceptors.response.use(
       const refreshToken = localStorage.getItem("refresh");
 
       return axiosInstance
-        .post("/token/refresh/", { refresh: refreshToken })
+        .post(tokenRefreshEndpoint, { refresh: refreshToken })
         .then(response => {
           localStorage.setItem("token", response.data.access);
           localStorage.setItem("refresh", response.data.refresh);

--- a/client/src/dashboard/StudentDashboard.tsx
+++ b/client/src/dashboard/StudentDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import axiosInstance from "../axiosAPI";
+import { studentDashboardEndpoint } from "../apiEndpoints";
 
 type CurrentProgram = {
   name: string;
@@ -35,7 +36,7 @@ export default class StudentDashboard extends Component<Props, State> {
   }
 
   getStudentDashboard() {
-    axiosInstance.get("/studentdashboard/").then(res => {
+    axiosInstance.get(studentDashboardEndpoint).then(res => {
       this.setState({
         programs: res.data.current,
         previousPrograms: res.data.previous,

--- a/client/src/dashboard/TeacherDashboard.tsx
+++ b/client/src/dashboard/TeacherDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import axiosInstance from "../axiosAPI";
+import { teacherDashboardEndpoint } from "../apiEndpoints";
 
 type JSONProgram = {
   name: string;
@@ -44,7 +45,7 @@ export default class TeacherDashboard extends Component<Props, State> {
   }
 
   getPrograms() {
-    axiosInstance.get("/teacherprograms/").then(res => {
+    axiosInstance.get(teacherDashboardEndpoint).then(res => {
       this.setState({ programs: this.generateProgramList(res.data.results) });
     });
   }

--- a/client/src/registration/DummyForm.tsx
+++ b/client/src/registration/DummyForm.tsx
@@ -10,7 +10,9 @@ type Props = {
   url: string;
 };
 
-type State = {};
+type State = {
+  endpoint: string;
+};
 
 // This is a placeholder for forms that haven't been implemented yet
 // All they do is mark the form as completed in the backend on submit
@@ -18,13 +20,15 @@ type State = {};
 class DummyForm extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = {};
+    this.state = {
+      endpoint: `/${this.props.program}/${this.props.edition}/${this.props.url}`,
+    };
   }
 
   handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     axiosInstance
-      .post(this.props.url, {
+      .post(this.state.endpoint, {
         program: this.props.program,
         edition: this.props.edition,
       })

--- a/client/src/registration/DummyForm.tsx
+++ b/client/src/registration/DummyForm.tsx
@@ -24,7 +24,7 @@ class DummyForm extends Component<Props, State> {
   handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     axiosInstance
-      .post("/" + this.props.url + "/", {
+      .post(this.props.url, {
         program: this.props.program,
         edition: this.props.edition,
       })

--- a/client/src/registration/EmergencyInfoForm.tsx
+++ b/client/src/registration/EmergencyInfoForm.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import axiosInstance from "../axiosAPI";
 import { navigate } from "@reach/router";
+import { emergencyInfoEndpoint } from "../apiEndpoints";
 
 type Props = {
   isStudent: boolean;
@@ -30,7 +31,7 @@ class EmergencyInfoForm extends Component<Props, State> {
 
   getEmergencyInfo() {
     axiosInstance
-      .get("/emergency_info/", {
+      .get(emergencyInfoEndpoint, {
         params: {
           program: this.props.program,
           edition: this.props.edition,
@@ -56,7 +57,7 @@ class EmergencyInfoForm extends Component<Props, State> {
   handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     axiosInstance
-      .post("/emergency_info/", {
+      .post(emergencyInfoEndpoint, {
         program: this.props.program,
         edition: this.props.edition,
       })

--- a/client/src/registration/EmergencyInfoForm.tsx
+++ b/client/src/registration/EmergencyInfoForm.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 type State = {
-  something: string;
+  endpoint: string;
 };
 
 function isValidField(prop: string, obj: State): prop is keyof State {
@@ -21,7 +21,7 @@ class EmergencyInfoForm extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      something: "",
+      endpoint: `/${this.props.program}/${this.props.edition}/${emergencyInfoEndpoint}`,
     };
   }
 
@@ -31,7 +31,7 @@ class EmergencyInfoForm extends Component<Props, State> {
 
   getEmergencyInfo() {
     axiosInstance
-      .get(emergencyInfoEndpoint, {
+      .get(this.state.endpoint, {
         params: {
           program: this.props.program,
           edition: this.props.edition,
@@ -57,7 +57,7 @@ class EmergencyInfoForm extends Component<Props, State> {
   handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     axiosInstance
-      .post(emergencyInfoEndpoint, {
+      .post(this.state.endpoint, {
         program: this.props.program,
         edition: this.props.edition,
       })

--- a/client/src/registration/StudentRegDashboard.tsx
+++ b/client/src/registration/StudentRegDashboard.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import axiosInstance from "../axiosAPI";
 import { RegStatusOption } from "./types";
+import { studentRegEndpoint } from "../apiEndpoints";
 
 type Props = {
   loggedIn: boolean;
@@ -75,7 +76,7 @@ class StudentRegDashboard extends Component<Props, State> {
 
   getStudentReg() {
     axiosInstance
-      .get("/current_studentreg/", {
+      .get(studentRegEndpoint, {
         params: {
           program: this.props.program,
           edition: this.props.edition,

--- a/client/src/registration/StudentRegDashboard.tsx
+++ b/client/src/registration/StudentRegDashboard.tsx
@@ -76,12 +76,7 @@ class StudentRegDashboard extends Component<Props, State> {
 
   getStudentReg() {
     axiosInstance
-      .get(studentRegEndpoint, {
-        params: {
-          program: this.props.program,
-          edition: this.props.edition,
-        },
-      })
+      .get(`/${this.props.program}/${this.props.edition}/${studentRegEndpoint}`)
       .then(res => {
         this.setState({
           availabilityCheck: res.data.availability_check,

--- a/client/src/registration/UpdateProfileForm.tsx
+++ b/client/src/registration/UpdateProfileForm.tsx
@@ -3,6 +3,7 @@ import axiosInstance from "../axiosAPI";
 import { navigate } from "@reach/router";
 import { PronounOptions } from "../constants";
 import { renderCustomInput, renderLabeledInput, renderLabeledSelect } from "../forms/helpers";
+import { studentProfileEndpoint } from "../apiEndpoints";
 
 type Props = {
   edition: string;
@@ -54,7 +55,7 @@ class UpdateProfileForm extends Component<Props, State> {
   }
 
   getProfileInfo() {
-    axiosInstance.get("/profile/").then(res => {
+    axiosInstance.get(studentProfileEndpoint).then(res => {
       this.setState({
         affiliation: res.data.affiliation,
         city: res.data.city,
@@ -86,7 +87,7 @@ class UpdateProfileForm extends Component<Props, State> {
   handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     axiosInstance
-      .post("/profile/", {
+      .post(studentProfileEndpoint, {
         affiliation: this.state.affiliation,
         city: this.state.city,
         country: this.state.country,

--- a/server/core/permissions.py
+++ b/server/core/permissions.py
@@ -1,24 +1,62 @@
+from core.models import Program, StudentRegistration
 from rest_framework import permissions
 
 
-class StudentPermission(permissions.BasePermission):
+class IsStudent(permissions.BasePermission):
     message = "This is a student-only action."
 
     def has_permission(self, request, view):
         return request.user.is_authenticated and request.user.is_student
 
 
-class TeacherPermission(permissions.BasePermission):
+class IsTeacher(permissions.BasePermission):
     message = "This is a teacher-only action."
 
     def has_permission(self, request, view):
         return request.user.is_authenticated and request.user.is_teacher
 
 
-class StudentOrTeacherPermission(permissions.BasePermission):
-    message = "Only students and teachers can perform this action."
+class ProgramStudentRegOpen(permissions.BasePermission):
+    message = "Student registration is not open for this program."
 
-    def has_permission(self, request, view):
-        return request.user.is_authenticated and (
-            request.user.is_student or request.user.is_teacher
-        )
+    def has_object_permission(self, request, view, obj):
+        if not isinstance(obj, Program):
+            return True
+        return obj.student_reg_open
+
+
+class StudentHasBegunRegistration(permissions.BasePermission):
+    message = "You cannot perform this action until you have begun the registration process."
+
+    def has_object_permission(self, request, view, obj):
+        if isinstance(obj, Program):
+            user = request.user
+            return StudentRegistration.objects.filter(student=user, program=obj).exists()
+        elif isinstance(obj, StudentRegistration):
+            return True
+        else:
+            return True
+
+
+class NoMedliabCheck(permissions.BasePermission):
+    message = "You have already filled out the medical liability form."
+
+    def has_object_permission(self, request, view, obj):
+        if isinstance(obj, StudentRegistration):
+            return not obj.medliab_check
+        elif isinstance(obj, StudentRegistration):
+            return True
+        else:
+            return True
+
+
+class NoLiabilityCheck(permissions.BasePermission):
+    message = "You have already filled out the liability waiver."
+
+    def has_object_permission(self, request, view, obj):
+        if isinstance(obj, StudentRegistration):
+            return not obj.liability_check
+        elif isinstance(obj, StudentRegistration):
+            return True
+        else:
+            return True

--- a/server/core/urls.py
+++ b/server/core/urls.py
@@ -6,7 +6,7 @@ from rest_framework_simplejwt import views as jwt_views
 from . import views
 
 router = routers.DefaultRouter()
-router.register("teacherprograms", views.TeacherProgramViewSet)
+router.register("dashboard/teacher/", views.TeacherProgramViewSet)
 
 app_name = "core"
 urlpatterns = [
@@ -63,17 +63,18 @@ urlpatterns = [
     path("api/studentclasses/", views.StudentProgramClasses.as_view()),
     path("api/", include(router.urls)),
     # Dashboard
-    path("api/studentdashboard/", views.get_student_dashboard),
+    path("api/dashboard/student/", views.get_student_dashboard),
+    # Profile
+    path("api/profile/student/", views.Profile.as_view()),
     # studentreg
-    path("api/current_studentreg/", views.current_studentreg),
-    path("api/profile/", views.Profile.as_view()),
-    path("api/emergency_info/", views.EmergencyInfo.as_view()),
-    path("api/medliab/", views.MedicalLiability.as_view()),
-    path("api/waiver/", views.LiabilityWaiver.as_view()),
-    path("api/availability/", views.Availability.as_view()),
+    path("api/<program>/<edition>/student/", views.StudentRegAPI.as_view()),
+    path("api/<program>/<edition>/student/emergency_info/", views.EmergencyInfo.as_view()),
+    path("api/<program>/<edition>/student/medliab/", views.MedicalLiability.as_view()),
+    path("api/<program>/<edition>/student/waiver/", views.LiabilityWaiver.as_view()),
+    path("api/<program>/<edition>/student/availability/", views.Availability.as_view()),
     # auth API calls
-    path("api/add_student/", views.CreateStudent.as_view()),  # TODO: change during big api rehaul
-    path("api/current_user/", views.current_user),
+    path("api/account/", views.UserAccount.as_view()),
+    path("api/user/", views.current_user),
     path("api/token/", jwt_views.TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/token/refresh/", jwt_views.TokenRefreshView.as_view(), name="token_refresh"),
     # for heroku

--- a/server/core/urls.py
+++ b/server/core/urls.py
@@ -73,7 +73,7 @@ urlpatterns = [
     path("api/<program>/<edition>/student/waiver/", views.LiabilityWaiver.as_view()),
     path("api/<program>/<edition>/student/availability/", views.Availability.as_view()),
     # auth API calls
-    path("api/account/", views.UserAccount.as_view()),
+    path("api/account/student/", views.StudentAccount.as_view()),
     path("api/user/", views.current_user),
     path("api/token/", jwt_views.TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/token/refresh/", jwt_views.TokenRefreshView.as_view(), name="token_refresh"),

--- a/server/core/views/api.py
+++ b/server/core/views/api.py
@@ -27,7 +27,7 @@ def current_user(request):
     return Response(serializer.data)
 
 
-class UserAccount(APIView):
+class StudentAccount(APIView):
     """
     Create a new student and return the access/refresh token pair.
     This is used during the signup process.

--- a/server/core/views/api.py
+++ b/server/core/views/api.py
@@ -198,7 +198,7 @@ class EmergencyInfo(APIView):
         # TODO add correction checks
         return Response({"message": "Success!"})
 
-    def get_object(self, program=None, edition=None):
+    def get_object(self, program, edition):
         user = self.request.user
         program = Program.objects.get(name=program, edition=edition)
         # TODO add check for if studentreg object exists
@@ -228,12 +228,11 @@ class MedicalLiability(APIView):
         # TODO add correction checks
         return Response({"message": "Success!"})
 
-    def get_object(self, program=None, edition=None):
+    def get_object(self, program, edition):
         user = self.request.user
         program = Program.objects.get(name=program, edition=edition)
         # TODO add check for if studentreg object exists
         studentreg = StudentRegistration.objects.get(student=user, program=program)
-        self.check_object_permissions(self.request, studentreg)
 
         return studentreg
 
@@ -258,12 +257,11 @@ class LiabilityWaiver(APIView):
         # TODO add correction checks
         return Response({"message": "Success!"})
 
-    def get_object(self, program=None, edition=None):
+    def get_object(self, program, edition):
         user = self.request.user
         program = Program.objects.get(name=program, edition=edition)
         # TODO add check for if studentreg object exists
         studentreg = StudentRegistration.objects.get(student=user, program=program)
-        self.check_object_permissions(self.request, studentreg)
 
         return studentreg
 
@@ -288,7 +286,7 @@ class Availability(APIView):
         # TODO add correction checks
         return Response({"message": "Success!"})
 
-    def get_object(self, program=None, edition=None):
+    def get_object(self, program, edition):
         user = self.request.user
         program = Program.objects.get(name=program, edition=edition)
         # TODO add check for if studentreg object exists
@@ -324,3 +322,6 @@ class StudentProgramClasses(APIView):
         }
 
         return Response(ret)
+
+
+# TODO figure out object permissions


### PR DESCRIPTION
Move all API URLs in the frontend to a separate file, so you don't have to go hunting for the URLs to edit them
Change the API URL hierarchy to follow standard REST API practice ([source](https://medium.com/hashmapinc/rest-good-practices-for-api-design-881439796dc9)) ([hierarchy](https://docs.google.com/document/d/1lgPza4EP7eM_kbxA9F6Uxt7tgZgLjZsbVQwhNVYJUS4/edit))
Rename/create more permissions (some of these aren't really used because I can't figure out how)