### PR TITLE
Fix trailing slash handling

### DIFF
--- a/server/core/urls.py
+++ b/server/core/urls.py
@@ -30,6 +30,9 @@ urlpatterns = [
     path("api/user/", views.current_user),
     path("api/token/", jwt_views.TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/token/refresh/", jwt_views.TokenRefreshView.as_view(), name="token_refresh"),
-    # for heroku
-    re_path(".*", TemplateView.as_view(template_name="index.html"), name="react"),
+    # Reroute all other paths to React frontend.
+    # The pattern has a trailing slash so it doesn't accidentally catch patterns without trailing
+    # slashes like "admin". (Django first checks "admin" and then checks "admin/" so we want to make
+    # sure "admin" is not caught by the React pattern.)
+    re_path("^.*/$", TemplateView.as_view(template_name="index.html"), name="react"),
 ]


### PR DESCRIPTION
Right now, we're catching all url patterns and sending them to React after one pass through the urlpatterns list. This means Django's trailing slash handling doesn't work (if a url doesn't have a trailing slash, it first makes one pass through urlpatterns, and if it doesn't match anything Django appends a slash and makes a second pass).

This is fixed if our React wildcard pattern requires a trailing slash at the end.

Testing: Lazily tested by checking localhost:8000/admin works.

Draft because I want to wait on #18 to get merged first.