### PR TITLE
Properly hash passwords when inputting sample data

### DIFF
--- a/server/sample_data/ESPUser.tsv
+++ b/server/sample_data/ESPUser.tsv
@@ -11,4 +11,4 @@ id	username	password	is_staff	is_superuser
 1023	teacher3	password	False	False
 1024	teacher4	password	False	False
 1040	edward	lobster	True	True
-1	root	root	True	True
+999	root	root	True	True

--- a/server/sample_data/ESPUser.tsv
+++ b/server/sample_data/ESPUser.tsv
@@ -11,4 +11,4 @@ id	username	password	is_staff	is_superuser
 1023	teacher3	password	False	False
 1024	teacher4	password	False	False
 1040	edward	lobster	True	True
-1   root    root    True    True
+1	root	root	True	True

--- a/server/sample_data/ESPUser.tsv
+++ b/server/sample_data/ESPUser.tsv
@@ -11,3 +11,4 @@ id	username	password	is_staff	is_superuser
 1023	teacher3	password	False	False
 1024	teacher4	password	False	False
 1040	edward	lobster	True	True
+1   root    root    True    True

--- a/server/setup_sample_data.py
+++ b/server/setup_sample_data.py
@@ -49,6 +49,9 @@ def resolve_ref_fields(model, data):
         if ref_model is not None:
             ref_obj = ref_model.objects.get(pk=value)
             data[field] = ref_obj
+        elif model == ESPUser and field == "password":
+            # properly hash passwords
+            data[field] = django.contrib.auth.hashers.make_password(value)
     return data
 
 


### PR DESCRIPTION
Name says it all. 

Also added the root account, since we all create it anyways, and passwords are being hashed properly. 

TEST:
* Examined the passwords in the shell and confirmed that they looked hashed
* Logged into the admin panel with the `edward` account (which previously didn't work)