### PR TITLE
Make default reg status for StudentRegistration equal to its program's

### DIFF
--- a/server/core/admin/__init__.py
+++ b/server/core/admin/__init__.py
@@ -146,7 +146,7 @@ class StudentRegistrationAdmin(admin.ModelAdmin):
 
     def add_view(self, request, extra_context=None):
         extra_context = extra_context or {}
-        self.fields = ("student", "program", "reg_status")
+        self.fields = ("student", "program")
         self.readonly_fields = ()
         self.inlines = []
         return super(StudentRegistrationAdmin, self).add_view(request, extra_context=extra_context)

--- a/server/core/models/registration.py
+++ b/server/core/models/registration.py
@@ -52,6 +52,12 @@ class StudentRegistration(models.Model):
     def __str__(self):
         return str(self.student.username) + "/" + str(self.program)
 
+    def save(self, *args, **kwargs):
+        if self.id is None:  # new object
+            if self.program is not None:
+                self.reg_status = self.program.student_reg_status
+        super(StudentRegistration, self).save(*args, **kwargs)
+
     @staticmethod
     def get_previous_programs(user):
         """

--- a/server/core/views/studentreg.py
+++ b/server/core/views/studentreg.py
@@ -24,7 +24,6 @@ class StudentRegAPI(APIView):
         prog = Program.objects.get(name=program, edition=edition)
 
         studentreg, _ = StudentRegistration.objects.get_or_create(student=user, program=prog)
-        # TODO figure out how to change the default regstatus based on the program's status
         return Response(StudentRegSerializer(studentreg).data)
 
 


### PR DESCRIPTION
Title says it all

Test:
* created object in admin panel, checked to make sure reg status equaled the program's
* created object in shell, checked to make sure reg status equaled the program's
* edited `reg_status` in the admin panel, made sure it changed properly (instead of refusing to change)