### PR TITLE
Add PrivateRoute component and redirect correctly

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,6 +18,7 @@ import Program, { programList } from "./info/Program";
 import Teach from "./info/Teach";
 import Footer from "./layout/Footer";
 import Nav from "./layout/Nav";
+import PrivateRoute from "./PrivateRoute";
 import RegDashboard from "./registration/RegDashboard";
 
 const NotFound = () => (
@@ -67,6 +68,7 @@ function App(props: {}) {
           <Home path="/" />
           {/* TODO: better page than homepage? Notification of logout success? */}
           <Home path="logout" />
+          <PrivateRoute path="nextup" as={Nextup} />
           <LoginPage path="login" username={userInfo.username} setToken={setToken} />
           <SignupPage path="signup" username={userInfo.username} setToken={setToken} />
 

--- a/client/src/PrivateRoute.tsx
+++ b/client/src/PrivateRoute.tsx
@@ -1,0 +1,17 @@
+import { navigate } from "@reach/router";
+import React, { useEffect } from "react";
+
+import { useLoggedIn } from "./context/auth";
+
+//@ts-ignore
+function PrivateRoute({ as: Component, ...props }) {
+  const loggedIn = useLoggedIn();
+  useEffect(() => {
+    if (!loggedIn) {
+      navigate("/login", { state: { referer: props.location } });
+    }
+  }, [loggedIn, props.location]);
+  return <Component {...props} />;
+}
+
+export default PrivateRoute;

--- a/client/src/PrivateRoute.tsx
+++ b/client/src/PrivateRoute.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from "react";
 
 import { useLoggedIn } from "./context/auth";
 
-//@ts-ignore
+//@ts-ignore TODO: fix
 function PrivateRoute({ as: Component, ...props }) {
   const loggedIn = useLoggedIn();
   useEffect(() => {

--- a/client/src/accounts/LoginForm.tsx
+++ b/client/src/accounts/LoginForm.tsx
@@ -7,7 +7,7 @@ import { renderStandardFormField } from "../forms/helpers";
 
 type Props = {
   setToken: (token: string) => void;
-  referer: string;
+  refererPath: string;
 };
 
 function LoginForm(props: Props) {
@@ -32,7 +32,7 @@ function LoginForm(props: Props) {
     login(username, password).then(result => {
       if (result.success) {
         props.setToken(result.info);
-        navigate(props.referer);
+        navigate(props.refererPath);
       } else {
         // TODO: will need to surface error to user
         console.log("Error with login " + result.info);

--- a/client/src/accounts/LoginForm.tsx
+++ b/client/src/accounts/LoginForm.tsx
@@ -3,22 +3,16 @@ import React, { useState } from "react";
 
 import { login } from "./manage";
 
-import { useLoggedIn } from "../context/auth";
 import { renderStandardFormField } from "../forms/helpers";
 
 type Props = {
   setToken: (token: string) => void;
-  location?: { state: { referer: string } };
+  referer: string;
 };
 
 function LoginForm(props: Props) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-
-  const loggedIn = useLoggedIn();
-
-  // If there was no referer, default to the dashboard.
-  const referer = props.location ? props.location.state.referer : "/dashboard";
 
   function handleChange(e: React.FormEvent<HTMLInputElement>) {
     const name = e.currentTarget.name;
@@ -38,19 +32,12 @@ function LoginForm(props: Props) {
     login(username, password).then(result => {
       if (result.success) {
         props.setToken(result.info);
-        // TODO: test referer in the future
-        navigate(referer);
+        navigate(props.referer);
       } else {
         // TODO: will need to surface error to user
         console.log("Error with login " + result.info);
       }
     });
-  }
-
-  // TODO: add in this redirect behavior, test with referer later.
-  // TODO: maybe move to LoginPage
-  if (loggedIn) {
-    navigate(referer);
   }
 
   return (

--- a/client/src/accounts/LoginPage.tsx
+++ b/client/src/accounts/LoginPage.tsx
@@ -14,17 +14,17 @@ function LoginPage(props: Props) {
   const loggedIn = useLoggedIn();
 
   // If there was no referer, default to the dashboard.
-  const referer = props.location.state?.referer.pathname || "/dashboard";
+  const refererPath = props.location.state?.referer.pathname || "/dashboard";
 
   if (loggedIn) {
-    navigate(referer);
+    navigate(refererPath);
   }
 
   return (
     <div className="container">
       <div className="columns">
         <div className="column is-6 is-offset-3">
-          <LoginForm setToken={props.setToken} referer={referer} />
+          <LoginForm setToken={props.setToken} refererPath={refererPath} />
         </div>
       </div>
     </div>

--- a/client/src/accounts/LoginPage.tsx
+++ b/client/src/accounts/LoginPage.tsx
@@ -1,3 +1,4 @@
+import { navigate } from "@reach/router";
 import React from "react";
 
 import LoginForm from "./LoginForm";
@@ -5,22 +6,28 @@ import LoginForm from "./LoginForm";
 import { useLoggedIn } from "../context/auth";
 
 type Props = {
-  username: string;
+  location: { state?: { referer: { pathname: string } } };
   setToken: (token: string) => void;
 };
 
 function LoginPage(props: Props) {
   const loggedIn = useLoggedIn();
 
+  // If there was no referer, default to the dashboard.
+  const referer = props.location.state?.referer.pathname || "/dashboard";
+
+  if (loggedIn) {
+    navigate(referer);
+  }
+
   return (
     <div className="container">
       <div className="columns">
         <div className="column is-6 is-offset-3">
-          {loggedIn ? <h3> Hi, {props.username}! </h3> : <LoginForm setToken={props.setToken} />}
+          <LoginForm setToken={props.setToken} referer={referer} />
         </div>
       </div>
     </div>
-    //TODO figure out how to get this to automatically change when logged in
   );
 }
 


### PR DESCRIPTION
Routes wrapped behind `PrivateRoute` will redirect to the login if user is not logged in. Upon logging in, the user is redirected to the original page they were viewing.
Currently, only `/nextup` is protected, for testing purposes.

Testing:
- not logged in, access `/nextup`, log in and verify that you are on the correct page
- access `/nextup` while logged in, verify that you are directed straight there
- log in normally, verify that you are redirected to the dashboard (default)