### PR TITLE
Set page titles on all accessible pages

### DIFF
--- a/client/src/accounts/LoginPage.tsx
+++ b/client/src/accounts/LoginPage.tsx
@@ -10,6 +10,8 @@ type Props = {
 };
 
 function LoginPage(props: Props) {
+  document.title = "Login | MIT ESP";
+
   const loggedIn = useLoggedIn();
 
   return (

--- a/client/src/accounts/SignupPage.tsx
+++ b/client/src/accounts/SignupPage.tsx
@@ -20,6 +20,10 @@ class SignupPage extends Component<Props, State> {
     };
   }
 
+  componentDidMount() {
+    document.title = "Sign up | MIT ESP";
+  }
+
   getButtonClass(signupType: SignupType) {
     return `button ${this.state.selectedSignupType === signupType ? "is-active" : ""}`;
   }

--- a/client/src/dashboard/Dashboard.tsx
+++ b/client/src/dashboard/Dashboard.tsx
@@ -6,6 +6,8 @@ import TeacherDashboard from "./TeacherDashboard";
 import { useAuth, useLoggedIn } from "../context/auth";
 
 function Dashboard(props: {}) {
+  document.title = "Dashboard | MIT ESP";
+
   const { username, isStudent, isTeacher } = useAuth();
   const loggedIn = useLoggedIn();
 

--- a/client/src/info/AboutUs.tsx
+++ b/client/src/info/AboutUs.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
 export default function AboutUs() {
+  document.title = "About us | MIT ESP";
+
   return (
     <div className="container content">
       <div className="columns">

--- a/client/src/info/Home.tsx
+++ b/client/src/info/Home.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 export default function Home() {
+  document.title = "MIT ESP";
   return (
     <div className="container content">
       <div className="columns">

--- a/client/src/info/Learn.tsx
+++ b/client/src/info/Learn.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
 export default function Learn() {
+  document.title = "Learn | MIT ESP";
   return <div>LEARN</div>;
 }

--- a/client/src/info/Nextup.tsx
+++ b/client/src/info/Nextup.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 
 export default function Nextup() {
+  document.title = "Next up for espider";
   return (
     <div className="container content">
       <div className="has-text-centered pb-5">

--- a/client/src/info/Program.tsx
+++ b/client/src/info/Program.tsx
@@ -11,6 +11,8 @@ export const programList = ["splash", "spark", "hssp", "cascade", "firestorm"];
 //TODO: we could write this stuff in md format or something and generate it
 export default function Program(props: { program: string }) {
   const program = canonicalizeProgramName(props.program);
+  document.title = `${program} | MIT ESP`;
+
   return (
     <div className="container content">
       <h1 className="is-size-1 has-text-weight-bold">{program}</h1>

--- a/client/src/info/Teach.tsx
+++ b/client/src/info/Teach.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
 export default function Teach() {
+  document.title = "Teach | MIT ESP";
+
   return (
     <div className="container content">
       <div className="columns">

--- a/client/src/registration/RegDashboard.tsx
+++ b/client/src/registration/RegDashboard.tsx
@@ -21,6 +21,8 @@ type Props = {
 // component is functioning more like a "ProgramDashboard"
 
 function RegDashboard(props: Props) {
+  document.title = `${props.program} ${props.edition} | MIT ESP`;
+
   const { isStudent, isTeacher } = useAuth();
   const loggedIn = useLoggedIn();
 

--- a/client/src/registration/StudentRegistration.tsx
+++ b/client/src/registration/StudentRegistration.tsx
@@ -29,6 +29,8 @@ type Props = {
 
 // TODO: final confirmation state or page
 function StudentRegistration(props: Props) {
+  document.title = `${props.program} ${props.edition} Registration | MIT ESP`;
+
   // TODO: stateful "active" step selection based on progress on other steps
   // TODO: figure out general flow (can people go backwards?, etc)
   const [selectedStep, setSelectedStep] = useState(0);


### PR DESCRIPTION
In this SPA of ours, the page title doesn't change when the user navigates. Bad for accessibility, bad for navigation purposes.

This current solution is pretty bad because we have to manually mark every component that could directly routed to (all the "pages"). An alternate solution is to create a HOC `withTitle` that wraps all the components wherever we have routing (like in `App.tsx`). However, this is less flexible and means we won't be able to have dynamic page titles like "Splash 2019 Registration." Instead, it would just be "Program Registration" or something.

I could potentially go with a hybrid solution (`withTitle` HOC on the static pages, which will probably be server-rendered at some point in the future anyways, and custom title setting for the program specific pages).