### PR TITLE
Add Page HOC and apply to all reachable pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,16 +19,18 @@ import Teach from "./info/Teach";
 import Footer from "./layout/Footer";
 import Nav from "./layout/Nav";
 import PrivateRoute from "./PrivateRoute";
+import { contentPage } from "./layout/Page";
 import RegDashboard from "./registration/RegDashboard";
 
-const NotFound = () => (
-  <section className="pt-5 pb-5 container has-text-centered">
-    <p>Invalid URL. Sorry, nothing here!</p>
-    <p>
-      Return to the <a href="/">homepage</a>.
-    </p>
-  </section>
-);
+const NotFound = () =>
+  contentPage("404 Not found")(
+    <section className="pt-5 pb-5 container has-text-centered">
+      <p>Invalid URL. Sorry, nothing here!</p>
+      <p>
+        Return to the <a href="/">homepage</a>.
+      </p>
+    </section>
+  );
 
 function App(props: {}) {
   const [userInfo, setUserInfo] = useState({

--- a/client/src/accounts/LoginPage.tsx
+++ b/client/src/accounts/LoginPage.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import LoginForm from "./LoginForm";
 
 import { useLoggedIn } from "../context/auth";
+import { generalPage } from "../layout/Page";
 
 type Props = {
   location: { state?: { referer: { pathname: string } } };
@@ -20,12 +21,10 @@ function LoginPage(props: Props) {
     navigate(refererPath);
   }
 
-  return (
-    <div className="container">
-      <div className="columns">
-        <div className="column is-6 is-offset-3">
-          <LoginForm setToken={props.setToken} refererPath={refererPath} />
-        </div>
+  return generalPage("Login | MIT ESP")(
+    <div className="columns">
+      <div className="column is-6 is-offset-3">
+        <LoginForm setToken={props.setToken} refererPath={refererPath} />
       </div>
     </div>
   );

--- a/client/src/accounts/SignupPage.tsx
+++ b/client/src/accounts/SignupPage.tsx
@@ -6,6 +6,7 @@ import { SignupType } from "./types";
 
 import { logout } from "../accounts/manage";
 import { useAuth, useLoggedIn } from "../context/auth";
+import { generalPage } from "../layout/Page";
 
 type Props = {
   setToken: (token: string) => void;
@@ -46,7 +47,7 @@ function SignupPage(props: Props) {
   }
 
   function renderSignupForms() {
-    return (
+    return generalPage("Sign up | MIT ESP")(
       <React.Fragment>
         <h1 className="has-text-centered is-size-3">Sign Up</h1>
         <p>I am a...</p>

--- a/client/src/dashboard/Dashboard.tsx
+++ b/client/src/dashboard/Dashboard.tsx
@@ -4,17 +4,20 @@ import StudentDashboard from "./StudentDashboard";
 import TeacherDashboard from "./TeacherDashboard";
 
 import { useAuth, useLoggedIn } from "../context/auth";
+import { generalPage } from "../layout/Page";
 
 function Dashboard(props: {}) {
+  document.title = "Dashboard | MIT ESP";
+
   const { username, isStudent, isTeacher } = useAuth();
   const loggedIn = useLoggedIn();
 
   if (loggedIn) {
-    return (
-      <div className="container">
+    return generalPage("Login | MIT ESP")(
+      <React.Fragment>
         {isStudent && <StudentDashboard username={username} />}
         {isTeacher && <TeacherDashboard username={username} />}
-      </div>
+      </React.Fragment>
     );
   } else {
     // TODO: login screen, redirect?

--- a/client/src/info/AboutUs.tsx
+++ b/client/src/info/AboutUs.tsx
@@ -1,88 +1,88 @@
 import React from "react";
 
+import { contentPage } from "../layout/Page";
+
 export default function AboutUs() {
-  return (
-    <div className="container content">
-      <div className="columns">
-        <div className="column">
-          <img
-            className="level-item"
-            src="https://esp.mit.edu/media/images/theme/logo.png"
-            alt="excited students at programs"
-          />
-        </div>
-        <div className="column">
-          <b> About ESP </b> <br />
-          The MIT Educational Studies Program (ESP) was created by MIT students in 1957 so we could
-          make a difference in the Boston, Cambridge, and MIT communities by sharing our knowledge
-          and creativity with local high school students. Since then, we have grown to support well
-          over five thousand students each year with the help of MIT students like you.
-          <br /> <br />
-          ESP is a student group at MIT composed of undergraduate and graduate students. Members of
-          ESP work to organize and run our many programs, supported by our teachers and volunteers.
-          If you’re interested in getting involved behind-the-scenes, we invite you to come to our
-          weekly meetings and worksessions. More information is available here.
-          <br /> <br />
-          Through an extensive offering of academic and non-academic classes, ESP is dedicated to
-          providing a unique, affordable educational experience for motivated middle school and high
-          school students. ESP courses are developed and taught by MIT students, alumni, and
-          faculty, and members of the community.
-          <br /> <br />
-          Our students are given the chance to learn from passionate and knowledgeable teachers; our
-          teachers can gain experience developing their own curricula with access to students with
-          the strongest desire to learn. The result is a unique, dynamic curriculum and an
-          atmosphere of unparalleled energy. We are the largest student-run program of our kind in
-          the United States.
-          <br /> <br />
-          Our programs are guided by three main ideas:
-          <br />
-          <ol>
-            <li>Learning and teaching should be fun!</li>
-            <li>Participants should have as much choice as possible.</li>
-            <li>
-              Accessibility and equal access to educational opportunities for students is important.
-            </li>
-          </ol>
-        </div>
-        <div className="column">
-          <b> Our Educational Mission </b> <br />
-          The MIT Educational Studies Program (ESP) was created by MIT students in 1957 so we could
-          make a difference in the community by sharing our knowledge and creativity with local high
-          school students. Since then, we have grown to support well over three thousand students
-          each year with the help of hundreds of MIT students. Our original
-          <a href="/hssp"> High School Studies Program (HSSP)</a> has been joined by many other
-          enrichment <a href="/programs">programs</a> over the years, and our agenda changes each
-          year to best suit the community’s needs.
-          <br /> <br />
-          <b> More About ESP </b> <br />
-          Through an extensive offering of academic and non-academic classes, ESP is dedicated to
-          providing a unique, affordable educational experience for motivated middle school and high
-          school students. ESP is a great activity for teens in the Boston area. ESP classes are
-          developed and taught by MIT students, alumni, and faculty, and members of the community.
-          Our students are given the chance to learn from passionate and knowledgeable teachers; our
-          teachers can gain experience developing their own curricula with access to students with
-          the strongest desire to learn. The result is a unique, dynamic curriculum and an
-          atmosphere of unparalleled energy. We are the largest student-run program of our kind in
-          the United States.
-          <br /> <br />
-          ESP invites students from all walks of life for classes varying from completely fun and
-          non-academic (Duct Tape Design, Bottle Rockets) to the most advanced and challenging
-          (Build Your Own Operating System, Quantum Mechanics) available to high school students.
-          Our organization aims to provide exciting, thoughtful and meaningful classes for anyone
-          with the desire to learn.
-          <br /> <br />
-          <b> Variety and Experimentation </b> <br />
-          Teach Anything. Learn Anything. Do Anything. Really. No other student group puts on
-          programs involving a thousand high school students. Being part of ESP is being part of one
-          of the most unique organizations anywhere, an organization that is always filled with
-          energy and new ideas — and isn’t afraid of trying those new ideas out. Coming to an ESP
-          program means being a part of the cutting edge of education.
-          <br /> <br />
-          It is an astonishing thing to be a part of any ESP program as it happens, and it always
-          feels wonderful when all the pieces fall into place. ESP invites all members of the MIT
-          community and beyond to come to our office hours or meetings and learn more about our
-          organization.
-        </div>
+  return contentPage("Teach | MIT ESP")(
+    <div className="columns">
+      <div className="column">
+        <img
+          className="level-item"
+          src="https://esp.mit.edu/media/images/theme/logo.png"
+          alt="excited students at programs"
+        />
+      </div>
+      <div className="column">
+        <b> About ESP </b> <br />
+        The MIT Educational Studies Program (ESP) was created by MIT students in 1957 so we could
+        make a difference in the Boston, Cambridge, and MIT communities by sharing our knowledge and
+        creativity with local high school students. Since then, we have grown to support well over
+        five thousand students each year with the help of MIT students like you.
+        <br /> <br />
+        ESP is a student group at MIT composed of undergraduate and graduate students. Members of
+        ESP work to organize and run our many programs, supported by our teachers and volunteers. If
+        you’re interested in getting involved behind-the-scenes, we invite you to come to our weekly
+        meetings and worksessions. More information is available here.
+        <br /> <br />
+        Through an extensive offering of academic and non-academic classes, ESP is dedicated to
+        providing a unique, affordable educational experience for motivated middle school and high
+        school students. ESP courses are developed and taught by MIT students, alumni, and faculty,
+        and members of the community.
+        <br /> <br />
+        Our students are given the chance to learn from passionate and knowledgeable teachers; our
+        teachers can gain experience developing their own curricula with access to students with the
+        strongest desire to learn. The result is a unique, dynamic curriculum and an atmosphere of
+        unparalleled energy. We are the largest student-run program of our kind in the United
+        States.
+        <br /> <br />
+        Our programs are guided by three main ideas:
+        <br />
+        <ol>
+          <li>Learning and teaching should be fun!</li>
+          <li>Participants should have as much choice as possible.</li>
+          <li>
+            Accessibility and equal access to educational opportunities for students is important.
+          </li>
+        </ol>
+      </div>
+      <div className="column">
+        <b> Our Educational Mission </b> <br />
+        The MIT Educational Studies Program (ESP) was created by MIT students in 1957 so we could
+        make a difference in the community by sharing our knowledge and creativity with local high
+        school students. Since then, we have grown to support well over three thousand students each
+        year with the help of hundreds of MIT students. Our original
+        <a href="/hssp"> High School Studies Program (HSSP)</a> has been joined by many other
+        enrichment <a href="/programs">programs</a> over the years, and our agenda changes each year
+        to best suit the community’s needs.
+        <br /> <br />
+        <b> More About ESP </b> <br />
+        Through an extensive offering of academic and non-academic classes, ESP is dedicated to
+        providing a unique, affordable educational experience for motivated middle school and high
+        school students. ESP is a great activity for teens in the Boston area. ESP classes are
+        developed and taught by MIT students, alumni, and faculty, and members of the community. Our
+        students are given the chance to learn from passionate and knowledgeable teachers; our
+        teachers can gain experience developing their own curricula with access to students with the
+        strongest desire to learn. The result is a unique, dynamic curriculum and an atmosphere of
+        unparalleled energy. We are the largest student-run program of our kind in the United
+        States.
+        <br /> <br />
+        ESP invites students from all walks of life for classes varying from completely fun and
+        non-academic (Duct Tape Design, Bottle Rockets) to the most advanced and challenging (Build
+        Your Own Operating System, Quantum Mechanics) available to high school students. Our
+        organization aims to provide exciting, thoughtful and meaningful classes for anyone with the
+        desire to learn.
+        <br /> <br />
+        <b> Variety and Experimentation </b> <br />
+        Teach Anything. Learn Anything. Do Anything. Really. No other student group puts on programs
+        involving a thousand high school students. Being part of ESP is being part of one of the
+        most unique organizations anywhere, an organization that is always filled with energy and
+        new ideas — and isn’t afraid of trying those new ideas out. Coming to an ESP program means
+        being a part of the cutting edge of education.
+        <br /> <br />
+        It is an astonishing thing to be a part of any ESP program as it happens, and it always
+        feels wonderful when all the pieces fall into place. ESP invites all members of the MIT
+        community and beyond to come to our office hours or meetings and learn more about our
+        organization.
       </div>
     </div>
   );

--- a/client/src/info/Home.tsx
+++ b/client/src/info/Home.tsx
@@ -1,32 +1,32 @@
 import React from "react";
 
+import { contentPage } from "../layout/Page";
+
 export default function Home() {
-  return (
-    <div className="container content">
-      <div className="columns">
-        <div className="column">
-          <img
-            className="level-item"
-            src="https://qph.fs.quoracdn.net/main-qimg-338d75dbb172519677a52c5d7db1192d"
-            alt="school of fish"
-          />
-        </div>
-        <div className="column">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vel nunc ut enim sagittis
-          interdum. Vestibulum dapibus urna eu neque luctus maximus. Sed eu cursus nunc, id
-          imperdiet lorem. Praesent arcu felis, varius sed nibh eu, vehicula molestie nunc. Morbi ac
-          arcu id ante porttitor tempor. Suspendisse mollis tellus ipsum. Morbi pretium mi sit amet
-          eros consequat, ac ornare tortor lobortis. Morbi scelerisque sit amet dolor ac
-          ullamcorper. Curabitur eget ullamcorper ligula. Fusce bibendum bibendum massa. Nunc non
-          luctus est. Phasellus ante massa, condimentum vitae suscipit eget, cursus at nunc. Cras
-          porta, lorem et condimentum dapibus, velit ex laoreet purus, sit amet blandit mi urna eu
-          arcu. Aliquam porta felis et felis porta, et fermentum purus laoreet. Pellentesque
-          faucibus odio sit amet lectus finibus luctus. Pellentesque nec felis blandit, vulputate
-          nisi ac, porttitor justo. Cras at urna sit amet metus efficitur varius ac sit amet libero.
-          Mauris dictum lacus quis velit finibus, eget tincidunt erat feugiat.
-        </div>
-        <div className="column">Fish! Learn! Teach!</div>
+  return contentPage("MIT ESP")(
+    <div className="columns">
+      <div className="column">
+        <img
+          className="level-item"
+          src="https://qph.fs.quoracdn.net/main-qimg-338d75dbb172519677a52c5d7db1192d"
+          alt="school of fish"
+        />
       </div>
+      <div className="column">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vel nunc ut enim sagittis
+        interdum. Vestibulum dapibus urna eu neque luctus maximus. Sed eu cursus nunc, id imperdiet
+        lorem. Praesent arcu felis, varius sed nibh eu, vehicula molestie nunc. Morbi ac arcu id
+        ante porttitor tempor. Suspendisse mollis tellus ipsum. Morbi pretium mi sit amet eros
+        consequat, ac ornare tortor lobortis. Morbi scelerisque sit amet dolor ac ullamcorper.
+        Curabitur eget ullamcorper ligula. Fusce bibendum bibendum massa. Nunc non luctus est.
+        Phasellus ante massa, condimentum vitae suscipit eget, cursus at nunc. Cras porta, lorem et
+        condimentum dapibus, velit ex laoreet purus, sit amet blandit mi urna eu arcu. Aliquam porta
+        felis et felis porta, et fermentum purus laoreet. Pellentesque faucibus odio sit amet lectus
+        finibus luctus. Pellentesque nec felis blandit, vulputate nisi ac, porttitor justo. Cras at
+        urna sit amet metus efficitur varius ac sit amet libero. Mauris dictum lacus quis velit
+        finibus, eget tincidunt erat feugiat.
+      </div>
+      <div className="column">Fish! Learn! Teach!</div>
     </div>
   );
 }

--- a/client/src/info/Learn.tsx
+++ b/client/src/info/Learn.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { contentPage } from "../layout/Page";
+
 export default function Learn() {
-  return <div>LEARN</div>;
+  return contentPage("Learn | MIT ESP")(<h3>Learn</h3>);
 }

--- a/client/src/info/Nextup.tsx
+++ b/client/src/info/Nextup.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable */
 import React from "react";
+import { contentPage } from "../layout/Page";
 
 export default function Nextup() {
-  return (
-    <div className="container content">
+  return contentPage("Next up for espider")(
+    <React.Fragment>
       <div className="has-text-centered pb-5">
         <h1 className="title mb-2">Join us!</h1>
         <p className="has-text-weight-bold">
@@ -76,6 +77,6 @@ export default function Nextup() {
           </ul>
         </div>
       </div>
-    </div>
+    </React.Fragment>
   );
 }

--- a/client/src/info/Program.tsx
+++ b/client/src/info/Program.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { contentPage } from "../layout/Page";
+
 export function canonicalizeProgramName(program: string) {
   return program === "hssp"
     ? program.toUpperCase()
@@ -11,8 +13,9 @@ export const programList = ["splash", "spark", "hssp", "cascade", "firestorm"];
 //TODO: we could write this stuff in md format or something and generate it
 export default function Program(props: { program: string }) {
   const program = canonicalizeProgramName(props.program);
-  return (
-    <div className="container content">
+
+  return contentPage(`${program} | MIT ESP`)(
+    <React.Fragment>
       <h1 className="is-size-1 has-text-weight-bold">{program}</h1>
       <div className="columns">
         <div className="column">
@@ -39,6 +42,6 @@ export default function Program(props: { program: string }) {
           finibus, eget tincidunt erat feugiat.
         </div>
       </div>
-    </div>
+    </React.Fragment>
   );
 }

--- a/client/src/info/Teach.tsx
+++ b/client/src/info/Teach.tsx
@@ -1,39 +1,39 @@
 import React from "react";
 
+import { contentPage } from "../layout/Page";
+
 export default function Teach() {
-  return (
-    <div className="container content">
-      <div className="columns">
-        <div className="column">
-          <img
-            className="level-item"
-            src="https://compote.slate.com/images/1368eb56-12c0-4d83-a9fe-599ce8207023.jpg"
-            alt="teach teach teach"
-          />
-        </div>
-        <div className="column">
-          Teaching for ESP can be an extremely rewarding and educational experience. It can also be
-          as much or as little commitment as you like. If you would like to teach a one-time class,{" "}
-          <a href="/splash">Splash</a> (in November) and <a href="/spark">Spark</a> (in early March)
-          are great opportunities to teach about anything you want!
-          <a href="/hssp"> HSSP</a> (spring and summer) is a 6–10 week program that gives you the
-          opportunity to go more in-depth.
-          <br /> <br />
-          Moreover, we believe that teaching should be fun for you, as well as the students taking
-          your classes. Our motto is{" "}
-          <a href="/aboutus">“teach anything, learn anything, do anything”</a>
-          , and we hope our programs allow you to teach the subjects (academic or non-academic) that
-          you’re passionate about.
-          <br /> <br />
-          Teaching is also easier than you think! We can help you with advice, resources and helpful
-          hints. You can teach a lecture class about programming algorithms, an interactive
-          electronics class or maybe even teach yoga or martial arts. If you need resources for your
-          class, you can either buy them (check with directors to determine your budget) or we can
-          help you procure them. If you’d like advice or tips, check out our advice for teachers
-          section, or simply contact us with any questions or thoughts.
-        </div>
-        <div className="column">Fish! Teach!</div>
+  return contentPage("Teach | MIT ESP")(
+    <div className="columns">
+      <div className="column">
+        <img
+          className="level-item"
+          src="https://compote.slate.com/images/1368eb56-12c0-4d83-a9fe-599ce8207023.jpg"
+          alt="teach teach teach"
+        />
       </div>
+      <div className="column">
+        Teaching for ESP can be an extremely rewarding and educational experience. It can also be as
+        much or as little commitment as you like. If you would like to teach a one-time class,{" "}
+        <a href="/splash">Splash</a> (in November) and <a href="/spark">Spark</a> (in early March)
+        are great opportunities to teach about anything you want!
+        <a href="/hssp"> HSSP</a> (spring and summer) is a 6–10 week program that gives you the
+        opportunity to go more in-depth.
+        <br /> <br />
+        Moreover, we believe that teaching should be fun for you, as well as the students taking
+        your classes. Our motto is{" "}
+        <a href="/aboutus">“teach anything, learn anything, do anything”</a>
+        , and we hope our programs allow you to teach the subjects (academic or non-academic) that
+        you’re passionate about.
+        <br /> <br />
+        Teaching is also easier than you think! We can help you with advice, resources and helpful
+        hints. You can teach a lecture class about programming algorithms, an interactive
+        electronics class or maybe even teach yoga or martial arts. If you need resources for your
+        class, you can either buy them (check with directors to determine your budget) or we can
+        help you procure them. If you’d like advice or tips, check out our advice for teachers
+        section, or simply contact us with any questions or thoughts.
+      </div>
+      <div className="column">Fish! Teach!</div>
     </div>
   );
 }

--- a/client/src/layout/Page.tsx
+++ b/client/src/layout/Page.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+type PageStyle = "general" | "content" | "fullWidth";
+
+// NOTE: For now, the page functions take only an optional page parameter. This
+// could be extended to include other page-specific parameters.
+type GeneralProps = string;
+
+type PageProps = {
+  style: PageStyle;
+  title?: string;
+};
+
+function Page(props: PageProps) {
+  // NOTE: Current Page component only sets document title and returns a simple
+  // layout. This could be extended with more useful functions in the future.
+  if (props.title) {
+    document.title = props.title;
+  }
+
+  return (renderChildren: React.ReactNode) => {
+    switch (props.style) {
+      case "general":
+        return <div className="container">{renderChildren}</div>;
+      case "content":
+        return <div className="container content">{renderChildren}</div>;
+      case "fullWidth":
+        return renderChildren;
+    }
+  };
+}
+
+/**
+ * Use for content pages meant to convey information.
+ */
+function contentPage(title?: GeneralProps) {
+  return Page({ style: "content", title });
+}
+
+/**
+ * Use for general interaction pages, such as registration, class selection,
+ * dashboards, etc. Width will be constrained by viewport size.
+ */
+function generalPage(title?: GeneralProps) {
+  return Page({ style: "general", title });
+}
+
+/**
+ * Use for pages where we want as much information in view as possible and
+ * don't care about external usability.
+ */
+function fullWidthPage(title?: GeneralProps) {
+  return Page({ style: "fullWidth", title });
+}
+
+export { generalPage, contentPage, fullWidthPage };

--- a/client/src/registration/ChangeClassesDashboard.tsx
+++ b/client/src/registration/ChangeClassesDashboard.tsx
@@ -10,6 +10,7 @@ import {
 import axiosInstance from "../axiosAPI";
 import { renderCustomInput } from "../forms/helpers";
 import { renderLinkedText, renderTextInSection } from "../helperTextFunctions";
+import { generalPage } from "../layout/Page";
 
 type Props = {
   username: string;
@@ -283,8 +284,8 @@ class ClassChangesDashboard extends Component<Props, State> {
 
   render() {
     //TODO block view if studentreg isn't open (or something)
-    return (
-      <div className="container">
+    return generalPage("Class changes dashboard | MIT ESP")(
+      <React.Fragment>
         <h1 className="has-text-centered is-size-2">
           {this.props.program} {this.props.edition}: Change Classes
         </h1>
@@ -293,7 +294,7 @@ class ClassChangesDashboard extends Component<Props, State> {
           {this.renderClassSchedule()}
           {this.renderClassCatalog()}
         </div>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/client/src/registration/RegDashboard.tsx
+++ b/client/src/registration/RegDashboard.tsx
@@ -9,6 +9,7 @@ import { RegStatusOption } from "./types";
 import { studentRegEndpoint } from "../apiEndpoints";
 import axiosInstance from "../axiosAPI";
 import { useAuth, useLoggedIn } from "../context/auth";
+import { generalPage } from "../layout/Page";
 
 // import TeacherDashboard from "./TeacherRegDashboard";
 
@@ -48,9 +49,9 @@ function RegDashboard(props: Props) {
   }, [props.edition, props.program]);
 
   if (loggedIn) {
-    return (
+    return generalPage(`${props.program} ${props.edition} | MIT ESP`)(
       // TODO: create program-specific context and provider to subsequent components
-      <div className="container">
+      <React.Fragment>
         {isStudent && (
           // TODO: overarching application routing organization in one place
           <Router>
@@ -71,7 +72,7 @@ function RegDashboard(props: Props) {
         )}
 
         {isTeacher && true /*<TeacherRegDashboard username={username} />*/}
-      </div>
+      </React.Fragment>
     );
   } else {
     return <div></div>;

--- a/client/src/registration/StudentRegistration.tsx
+++ b/client/src/registration/StudentRegistration.tsx
@@ -12,8 +12,7 @@ import {
   medicalLiabilityEndpoint,
   studentAvailabilityEndpoint,
 } from "../apiEndpoints";
-
-// import { useAuth } from "../context/auth";
+import { generalPage } from "../layout/Page";
 
 type Props = {
   program: string;
@@ -79,14 +78,13 @@ function StudentRegistration(props: Props) {
       </li>
     );
   }
-
-  return (
-    <div className="container">
+  return generalPage(`${props.program} ${props.edition} Registration | MIT ESP`)(
+    <React.Fragment>
       <ul className="steps has-content-centered">
         {steps.map((step, index) => generateStep(step.name, step.text, index))}
       </ul>
       {steps[selectedStep].component}
-    </div>
+    </React.Fragment>
   );
 }
 


### PR DESCRIPTION
This adds a higher-order page component. `Page.tsx` exports three functions meant to wrap page-level components (components that have routes).

There are a few reasons to do this:
- standardize how pages are constructed, which makes things like spacing consistent. Useful in the future if we need to add site-wide banner components, make the shared layout more complex, or something similar.
- in some cases, decrease nesting in render functions
- make the changes from #47 feel less scattered. Now, the setting of `document.title` always happen in the page functions.
- allow for future extensiblity of the `Page` component. Shortlink tracking, whatever.

Weakness:
- still need to remember to use a page function for any "page" component. Optimally, we would be able to do this wrapping at the router level, but Reach Router is strict about what its children could be, and I wasn't clever enough to come with a different solution.

Testing:
- went to all the pages and made sure they looked the same. In some cases, they were improved because the original version had left out the `container` class on the outermost div.