### PR TITLE
Stop top-level App from rerendering on every route

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck TODO: fix
 import "./App.sass";
 
-import { Router } from "@reach/router";
+import { Router, Link } from "@reach/router";
 import React, { useEffect, useState } from "react";
 
 import LoginPage from "./accounts/LoginPage";
@@ -27,7 +27,7 @@ const NotFound = () =>
     <section className="pt-5 pb-5 container has-text-centered">
       <p>Invalid URL. Sorry, nothing here!</p>
       <p>
-        Return to the <a href="/">homepage</a>.
+      Return to the <Link to="/">homepage</Link>.
       </p>
     </section>
   );

--- a/client/src/dashboard/StudentDashboard.tsx
+++ b/client/src/dashboard/StudentDashboard.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@reach/router";
 import React, { Component } from "react";
 
 import { studentDashboardEndpoint } from "../apiEndpoints";
@@ -57,9 +58,9 @@ export default class StudentDashboard extends Component<Props, State> {
               return (
                 <h3 className="is-size-5" key={index}>
                   {program.name}:{" "}
-                  <a href={program.url + "/dashboard"}>
+                  <Link to={`${program.url}/dashboard`}>
                     {program.registered ? "Go to Dashboard" : "Register!!"}
-                  </a>
+                  </Link>
                 </h3>
               );
             })}
@@ -68,7 +69,7 @@ export default class StudentDashboard extends Component<Props, State> {
             {this.state.previousPrograms.map((program, index) => {
               return (
                 <h3 className="is-size-5" key={index}>
-                  {program.name}: <a href={`${program.url}/dashboard`}>View</a>
+                  {program.name}: <Link to={`${program.url}/dashboard`}>View</Link>
                 </h3>
               );
             })}

--- a/client/src/dashboard/TeacherDashboard.tsx
+++ b/client/src/dashboard/TeacherDashboard.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@reach/router";
 import React, { Component } from "react";
 
 import { teacherDashboardEndpoint } from "../apiEndpoints";
@@ -61,7 +62,7 @@ export default class TeacherDashboard extends Component<Props, State> {
             {this.state.programs.map((program, index) => {
               return (
                 <h3 className="is-size-5" key={index}>
-                  {program.name}: <a href={program.url}>Register</a>
+                  {program.name}: <Link to={program.url}>Register</Link>
                 </h3>
               );
             })}

--- a/client/src/helperTextFunctions.tsx
+++ b/client/src/helperTextFunctions.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@reach/router";
 import React from "react";
 
 function renderTextInSection(displayedText: string, centered = false) {
@@ -7,7 +8,7 @@ function renderTextInSection(displayedText: string, centered = false) {
 function renderLinkedText(displayedText: string, url: string) {
   return (
     <h3 className="is-size-5 has-text-centered">
-      <a href={url}>{displayedText}</a>
+      <Link to={url}>{displayedText}</Link>
     </h3>
   );
 }

--- a/client/src/info/AboutUs.tsx
+++ b/client/src/info/AboutUs.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@reach/router";
 import React from "react";
 
 import { contentPage } from "../layout/Page";
@@ -51,9 +52,9 @@ export default function AboutUs() {
         make a difference in the community by sharing our knowledge and creativity with local high
         school students. Since then, we have grown to support well over three thousand students each
         year with the help of hundreds of MIT students. Our original
-        <a href="/hssp"> High School Studies Program (HSSP)</a> has been joined by many other
-        enrichment <a href="/programs">programs</a> over the years, and our agenda changes each year
-        to best suit the community’s needs.
+        <Link to="/hssp"> High School Studies Program (HSSP)</Link> has been joined by many other
+        enrichment <Link to="/programs">programs</Link> over the years, and our agenda changes each
+        year to best suit the community’s needs.
         <br /> <br />
         <b> More About ESP </b> <br />
         Through an extensive offering of academic and non-academic classes, ESP is dedicated to

--- a/client/src/info/Teach.tsx
+++ b/client/src/info/Teach.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@reach/router";
 import React from "react";
 
 import { contentPage } from "../layout/Page";
@@ -15,14 +16,14 @@ export default function Teach() {
       <div className="column">
         Teaching for ESP can be an extremely rewarding and educational experience. It can also be as
         much or as little commitment as you like. If you would like to teach a one-time class,{" "}
-        <a href="/splash">Splash</a> (in November) and <a href="/spark">Spark</a> (in early March)
-        are great opportunities to teach about anything you want!
-        <a href="/hssp"> HSSP</a> (spring and summer) is a 6–10 week program that gives you the
+        <Link to="/splash">Splash</Link> (in November) and <Link to="/spark">Spark</Link> (in early
+        March) are great opportunities to teach about anything you want!
+        <Link to="/hssp"> HSSP</Link> (spring and summer) is a 6–10 week program that gives you the
         opportunity to go more in-depth.
         <br /> <br />
         Moreover, we believe that teaching should be fun for you, as well as the students taking
         your classes. Our motto is{" "}
-        <a href="/aboutus">“teach anything, learn anything, do anything”</a>
+        <Link to="/aboutus">“teach anything, learn anything, do anything”</Link>
         , and we hope our programs allow you to teach the subjects (academic or non-academic) that
         you’re passionate about.
         <br /> <br />

--- a/client/src/layout/Footer.tsx
+++ b/client/src/layout/Footer.tsx
@@ -1,9 +1,10 @@
+import { Link } from "@reach/router";
 import React from "react";
 
 const generateLink = (href: string, text: string) => (
-  <a className="has-text-link-dark" href={href}>
+  <Link className="has-text-link-dark" to={href}>
     {text}
-  </a>
+  </Link>
 );
 
 const generateLinksList = (linksInfo: string[][]) => (

--- a/client/src/layout/Nav.tsx
+++ b/client/src/layout/Nav.tsx
@@ -29,12 +29,12 @@ function Nav(props: Props) {
   function loggedOutView() {
     return (
       <div className="buttons">
-        <a className="button is-primary" href="/signup">
+        <Link className="button is-primary" to="/signup">
           <strong>Sign up</strong>
-        </a>
-        <a className="button is-light" href="/login">
+        </Link>
+        <Link className="button is-light" to="/login">
           Log In
-        </a>
+        </Link>
       </div>
     );
   }
@@ -42,23 +42,23 @@ function Nav(props: Props) {
   function loggedInView() {
     return (
       <div className="navbar-item has-dropdown is-hoverable">
-        <a className="navbar-link has-text-weight-bold" href="/dashboard">
+        <Link className="navbar-link has-text-weight-bold" to="/dashboard">
           {username}
-        </a>
+        </Link>
 
         <div className="navbar-dropdown is-right">
-          <a className="navbar-item" href="/dashboard">
+          <Link className="navbar-item" to="/dashboard">
             <span className="icon pr-3">
               <i className="fas fa-home"></i>
             </span>
             Dashboard
-          </a>
-          <a className="navbar-item" href="/profile">
+          </Link>
+          <Link className="navbar-item" to="/profile">
             <span className="icon pr-3">
               <i className="fas fa-user"></i>
             </span>
             Profile
-          </a>
+          </Link>
           <hr className="navbar-divider"></hr>
           <Link className="navbar-item" to="logout" onClick={handleLogout}>
             Log out
@@ -76,9 +76,9 @@ function Nav(props: Props) {
     >
       <div className="container">
         <div className="navbar-brand">
-          <a className="navbar-item has-text-weight-bold" href="/">
+          <Link className="navbar-item has-text-weight-bold" to="/">
             MIT ESP
-          </a>
+          </Link>
 
           <button
             type="button"
@@ -98,31 +98,31 @@ function Nav(props: Props) {
           {/* <div className="navbar-start"></div> */}
 
           <div className="navbar-end">
-            <a className="navbar-item has-text-weight-bold" href="/learn">
+            <Link className="navbar-item has-text-weight-bold" to="/learn">
               Learn
-            </a>
+            </Link>
 
-            <a className="navbar-item has-text-weight-bold" href="/teach">
+            <Link className="navbar-item has-text-weight-bold" to="/teach">
               Teach
-            </a>
+            </Link>
 
             <div className="navbar-item has-dropdown is-hoverable">
-              <a className="navbar-link has-text-weight-bold" href="/programs">
+              <Link className="navbar-link has-text-weight-bold" to="/programs">
                 Programs
-              </a>
+              </Link>
 
               <div className="navbar-dropdown">
                 {programList.map(program => (
-                  <a className="navbar-item" key={program} href={`/${program}`}>
+                  <Link className="navbar-item" key={program} to={`/${program}`}>
                     {canonicalizeProgramName(program)}
-                  </a>
+                  </Link>
                 ))}
               </div>
             </div>
 
-            <a className="navbar-item has-text-weight-bold" href="/aboutus">
+            <Link className="navbar-item has-text-weight-bold" to="/aboutus">
               About Us
-            </a>
+            </Link>
           </div>
           <div className="navbar-item">{loggedIn ? loggedInView() : loggedOutView()}</div>
         </div>

--- a/client/src/registration/StudentRegDashboard.tsx
+++ b/client/src/registration/StudentRegDashboard.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@reach/router";
 import React, { useEffect, useState } from "react";
 
 import { RegStatusOption, ScheduleItem } from "./types";
@@ -137,7 +138,7 @@ function StudentRegDashboard(props: Props) {
       <div className="columns">
         <div className="column">
           <h2 className="has-text-centered is-size-3 mb-2">Register</h2>
-          <a href="register">Registration steps</a>
+          <Link to="register">Registration steps</Link>
         </div>
         {renderClassStatus()}
       </div>


### PR DESCRIPTION
BUG: `App` was rerendering (and sending a new axios request to grab username, isStudent, etc.) every time you clicked on a link and requested a different route.

Turns out you have to use Reach Router's `<Link>` instead of `<a>`. Makes sense.

#idomybestworkat4am