### PR TITLE
Only retrieve schedule if a valid regstatus

### DIFF
--- a/client/src/registration/StudentRegDashboard.tsx
+++ b/client/src/registration/StudentRegDashboard.tsx
@@ -28,11 +28,27 @@ function StudentRegDashboard(props: Props) {
   const [schedule, setSchedule] = useState([] as ScheduleItem[]);
 
   useEffect(() => {
-    // Set up student classes
-    axiosInstance.get(`/${props.program}/${props.edition}/${studentScheduleEndpoint}`).then(res => {
-      setSchedule(res.data);
-    });
-  }, [props.edition, props.program]);
+    switch (props.regStatus) {
+      case RegStatusOption.ClassPreferences:
+        // TODO set up class preferences
+        break;
+
+      case RegStatusOption.ChangeClasses ||
+        RegStatusOption.PreProgram ||
+        RegStatusOption.DayOf ||
+        RegStatusOption.PostProgram:
+        // Set up student classes
+        axiosInstance
+          .get(`/${props.program}/${props.edition}/${studentScheduleEndpoint}`)
+          .then(res => {
+            setSchedule(res.data);
+          });
+        break;
+
+      default:
+        console.log("Something broke :(");
+    }
+  }, [props.edition, props.program, props.regStatus]);
 
   function renderClassPrefs(editsAllowed: boolean = false) {
     return (


### PR DESCRIPTION
The schedule is currently always retrieved in the reg dashboard. This is an edit to ensure that it is only retrieved if the student has a valid registration status.

Test:
* checked whether the API call was made based on the reg status
* made sure the schedule rendered correctly if in a valid reg status