### PR TITLE
Reorganize frontend program-specific links

### DIFF
--- a/client/src/apiEndpoints.ts
+++ b/client/src/apiEndpoints.ts
@@ -1,44 +1,26 @@
 // Accounts
-const loginEndpoint = "/token/";
-const tokenRefreshEndpoint = "/token/refresh/";
-const userDataEndpoint = "/user/";
-const studentSignupEndpoint = "/account/student/";
+export const loginEndpoint = "/token/";
+export const tokenRefreshEndpoint = "/token/refresh/";
+export const userDataEndpoint = "/user/";
+export const studentSignupEndpoint = "/account/student/";
 
 // Profile
-const studentProfileEndpoint = "/profile/student/";
+export const studentProfileEndpoint = "/profile/student/";
 
 // Dashboards
-const studentDashboardEndpoint = "/dashboard/student/";
-const teacherDashboardEndpoint = "/dashboard/teacher/";
+export const studentDashboardEndpoint = "/dashboard/student/";
+export const teacherDashboardEndpoint = "/dashboard/teacher/";
 
 // Program-specific (these requires /program/edition/ before)
 
-const classCatalogEndpoint = "catalog/";
+export const classCatalogEndpoint = "catalog/";
 
 // studentreg
-const studentRegEndpoint = "student/";
-const studentRemoveClassesEndpoint = "student/classes/remove/";
+export const studentRegEndpoint = "student/";
+export const studentRemoveClassesEndpoint = "student/classes/remove/";
 
-const emergencyInfoEndpoint = "student/emergency_info/";
-const medicalLiabilityEndpoint = "student/medliab/";
-const liabilityWaiverEndpoint = "student/waiver/";
-const studentAvailabilityEndpoint = "student/availability/";
-const studentScheduleEndpoint = "student/schedule/";
-
-export {
-  loginEndpoint,
-  tokenRefreshEndpoint,
-  userDataEndpoint,
-  studentSignupEndpoint,
-  studentDashboardEndpoint,
-  teacherDashboardEndpoint,
-  classCatalogEndpoint,
-  studentRegEndpoint,
-  emergencyInfoEndpoint,
-  studentProfileEndpoint,
-  medicalLiabilityEndpoint,
-  liabilityWaiverEndpoint,
-  studentAvailabilityEndpoint,
-  studentScheduleEndpoint,
-  studentRemoveClassesEndpoint,
-};
+export const emergencyInfoEndpoint = "student/emergency_info/";
+export const medicalLiabilityEndpoint = "student/medliab/";
+export const liabilityWaiverEndpoint = "student/waiver/";
+export const studentAvailabilityEndpoint = "student/availability/";
+export const studentScheduleEndpoint = "student/schedule/";

--- a/client/src/dashboard/StudentDashboard.tsx
+++ b/client/src/dashboard/StudentDashboard.tsx
@@ -4,6 +4,7 @@ import React, { Component } from "react";
 import { studentDashboardEndpoint } from "../apiEndpoints";
 import axiosInstance from "../axiosAPI";
 import { generalPage } from "../layout/Page";
+import { dashboardURL } from "../registration/urls";
 
 type CurrentProgram = {
   name: string;
@@ -59,7 +60,7 @@ export default class StudentDashboard extends Component<Props, State> {
               return (
                 <h3 className="is-size-5" key={index}>
                   {program.name}:{" "}
-                  <Link to={`/${program.url}/dashboard`}>
+                  <Link to={`/${program.url}/${dashboardURL}`}>
                     {program.registered ? "Go to Dashboard" : "Register!!"}
                   </Link>
                 </h3>
@@ -70,7 +71,7 @@ export default class StudentDashboard extends Component<Props, State> {
             {this.state.previousPrograms.map((program, index) => {
               return (
                 <h3 className="is-size-5" key={index}>
-                  {program.name}: <Link to={`/${program.url}/dashboard`}>View</Link>
+                  {program.name}: <Link to={`/${program.url}/${dashboardURL}`}>View</Link>
                 </h3>
               );
             })}

--- a/client/src/registration/ChangeClassesDashboard.tsx
+++ b/client/src/registration/ChangeClassesDashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 
 import { Class, ScheduleItem, Section } from "./types";
+import { dashboardURL } from "./urls";
 
 import {
   studentScheduleEndpoint,
@@ -90,7 +91,7 @@ function ClassChangesDashboard(props: Props) {
             </tbody>
           </table>
         </div>
-        {renderLinkedText("Back to Dashboard", "../dashboard")}
+        {renderLinkedText("Back to Dashboard", `../${dashboardURL}`)}
       </div>
     );
   }

--- a/client/src/registration/DummyForm.tsx
+++ b/client/src/registration/DummyForm.tsx
@@ -1,6 +1,8 @@
 import { navigate } from "@reach/router";
 import React, { Component } from "react";
 
+import { dashboardURL } from "./urls";
+
 import axiosInstance from "../axiosAPI";
 
 type Props = {
@@ -33,7 +35,7 @@ class DummyForm extends Component<Props, State> {
         edition: this.props.edition,
       })
       .then(result => {
-        navigate("dashboard");
+        navigate(dashboardURL);
       });
   };
 

--- a/client/src/registration/EmergencyInfoForm.tsx
+++ b/client/src/registration/EmergencyInfoForm.tsx
@@ -1,6 +1,8 @@
 import { navigate } from "@reach/router";
 import React, { Component } from "react";
 
+import { dashboardURL } from "./urls";
+
 import { emergencyInfoEndpoint } from "../apiEndpoints";
 import axiosInstance from "../axiosAPI";
 
@@ -64,7 +66,7 @@ class EmergencyInfoForm extends Component<Props, State> {
       })
       .then(result => {
         /*TODO check validity of submitted data*/
-        navigate("dashboard");
+        navigate(dashboardURL);
       });
   };
 

--- a/client/src/registration/RegDashboard.tsx
+++ b/client/src/registration/RegDashboard.tsx
@@ -5,6 +5,7 @@ import ChangeClassesDashboard from "./ChangeClassesDashboard";
 import StudentRegDashboard from "./StudentRegDashboard";
 import StudentRegistration from "./StudentRegistration";
 import { RegStatusOption } from "./types";
+import { dashboardURL, registerURL, classChangesURL } from "./urls";
 
 import { studentRegEndpoint } from "../apiEndpoints";
 import axiosInstance from "../axiosAPI";
@@ -55,19 +56,19 @@ function RegDashboard(props: Props) {
         {isStudent && (
           // TODO: overarching application routing organization in one place
           <Router primary={false}>
-            <Redirect from="/" to="dashboard" noThrow />
+            <Redirect from="/" to={dashboardURL} noThrow />
             <StudentRegDashboard
               /* @ts-ignore TODO: reach-router path fix */
-              path="dashboard"
+              path={dashboardURL}
               checks={regChecks}
               regStatus={regStatus}
               program={props.program}
               edition={props.edition}
             />
             {/* @ts-ignore TODO: reach-router path fix */}
-            <StudentRegistration path="register" checks={regChecks} />
+            <StudentRegistration path={registerURL} checks={regChecks} />
             {/* @ts-ignore TODO: reach-router path fix */}
-            <ChangeClassesDashboard path="changeclasses" />
+            <ChangeClassesDashboard path={classChangesURL} />
           </Router>
         )}
 

--- a/client/src/registration/StudentRegDashboard.tsx
+++ b/client/src/registration/StudentRegDashboard.tsx
@@ -2,6 +2,7 @@ import { Link } from "@reach/router";
 import React, { useEffect, useState } from "react";
 
 import { RegStatusOption, ScheduleItem } from "./types";
+import { registerURL, classChangesURL } from "./urls";
 
 import { studentScheduleEndpoint } from "../apiEndpoints";
 import axiosInstance from "../axiosAPI";
@@ -70,7 +71,7 @@ function StudentRegDashboard(props: Props) {
             })}
           </tbody>
         </table>
-        {editsAllowed && renderLinkedText("Edit class schedule", "../changeclasses")}
+        {editsAllowed && renderLinkedText("Edit class schedule", `../${classChangesURL}`)}
       </div>
     );
   }
@@ -138,7 +139,7 @@ function StudentRegDashboard(props: Props) {
       <div className="columns">
         <div className="column">
           <h2 className="has-text-centered is-size-3 mb-2">Register</h2>
-          <Link to="../register">Registration steps</Link>
+          <Link to={`../${registerURL}`}>Registration steps</Link>
         </div>
         {renderClassStatus()}
       </div>

--- a/client/src/registration/UpdateProfileForm.tsx
+++ b/client/src/registration/UpdateProfileForm.tsx
@@ -1,6 +1,8 @@
 import { navigate } from "@reach/router";
 import React, { useEffect, useState } from "react";
 
+import { dashboardURL } from "./urls";
+
 import { studentProfileEndpoint } from "../apiEndpoints";
 import axiosInstance from "../axiosAPI";
 import {
@@ -87,7 +89,7 @@ function UpdateProfileForm(props: Props) {
       })
       .then(result => {
         /*TODO check validity of submitted data*/
-        navigate("dashboard");
+        navigate(dashboardURL);
       });
   }
 

--- a/client/src/registration/urls.ts
+++ b/client/src/registration/urls.ts
@@ -1,0 +1,3 @@
+export const dashboardURL = "dashboard";
+export const registerURL = "register";
+export const classChangesURL = "changeclasses";


### PR DESCRIPTION
* Move program-specific links to a separate file
* Change exporting method in `apiEndpoints` (so there didn't need to be another list of variables at the bottom)

Test:
* Went to all the pages, made sure they rendered correctly
* Checked all the links