### PR TITLE
Make program-specific routes API-based

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -59,7 +59,7 @@ function App(props: {}) {
     axiosInstance.get(programsEndpoint).then(result => {
       setPrograms(result.data);
     });
-  });
+  }, []);
 
   function setToken(accessToken: string) {
     setAuthToken(accessToken);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react";
 
 import LoginPage from "./accounts/LoginPage";
 import SignupPage from "./accounts/SignupPage";
-import { userDataEndpoint } from "./apiEndpoints";
+import { userDataEndpoint, programsEndpoint } from "./apiEndpoints";
 import axiosInstance from "./axiosAPI";
 import { AuthContext } from "./context/auth";
 import Dashboard from "./dashboard/Dashboard";
@@ -13,13 +13,14 @@ import AboutUs from "./info/AboutUs";
 import Home from "./info/Home";
 import Learn from "./info/Learn";
 import Nextup from "./info/Nextup";
-import Program, { programList } from "./info/Program";
+import ProgramStatic, { programList } from "./info/Program";
 import Teach from "./info/Teach";
 import Footer from "./layout/Footer";
 import Nav from "./layout/Nav";
 import { contentPage } from "./layout/Page";
 import PrivateRoute from "./PrivateRoute";
 import RegDashboard from "./registration/RegDashboard";
+import { Program } from "./types";
 
 const NotFound = () =>
   contentPage("404 Not found")(
@@ -40,6 +41,7 @@ function App(props: {}) {
 
   const existingToken = localStorage.getItem("token") || "";
   const [authToken, setAuthToken] = useState(existingToken);
+  const [programs, setPrograms] = useState([] as Program[]);
 
   useEffect(() => {
     if (authToken) {
@@ -51,6 +53,9 @@ function App(props: {}) {
         });
       });
     }
+    axiosInstance.get(programsEndpoint).then(result => {
+      setPrograms(result.data);
+    });
   }, [authToken, props]);
 
   function setToken(accessToken: string) {
@@ -87,11 +92,19 @@ function App(props: {}) {
 
           {programList.map(program => (
             //  @ts-ignore TODO: reach-router path fix
-            <Program key={program} path={program} program={program} />
+            <ProgramStatic key={program} path={program} program={program} />
           ))}
 
           {/* @ts-ignore TODO: reach-router path fix */}
-          <RegDashboard path=":program/:edition/*" />
+          {programs.map((program, index) => (
+            <RegDashboard
+              key={index}
+              path={`${program.name}/${program.edition}/*`}
+              program={program.name}
+              edition={program.edition}
+            />
+            // TODO do something about the half-second it takes to render the page (maybe just caching)
+          ))}
           {/* @ts-ignore TODO: reach-router path fix */}
           <NotFound default />
         </Router>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,14 +13,14 @@ import AboutUs from "./info/AboutUs";
 import Home from "./info/Home";
 import Learn from "./info/Learn";
 import Nextup from "./info/Nextup";
-import ProgramStatic, { programList } from "./info/Program";
+import Program, { programList } from "./info/Program";
 import Teach from "./info/Teach";
 import Footer from "./layout/Footer";
 import Nav from "./layout/Nav";
 import { contentPage } from "./layout/Page";
 import PrivateRoute from "./PrivateRoute";
 import RegDashboard from "./registration/RegDashboard";
-import { Program } from "./types";
+import { ProgramModel } from "./types";
 
 const NotFound = () =>
   contentPage("404 Not found")(
@@ -41,7 +41,7 @@ function App(props: {}) {
 
   const existingToken = localStorage.getItem("token") || "";
   const [authToken, setAuthToken] = useState(existingToken);
-  const [programs, setPrograms] = useState([] as Program[]);
+  const [programs, setPrograms] = useState([] as ProgramModel[]);
 
   useEffect(() => {
     if (authToken) {
@@ -53,10 +53,13 @@ function App(props: {}) {
         });
       });
     }
+  }, [authToken, props]);
+
+  useEffect(() => {
     axiosInstance.get(programsEndpoint).then(result => {
       setPrograms(result.data);
     });
-  }, [authToken, props]);
+  });
 
   function setToken(accessToken: string) {
     setAuthToken(accessToken);
@@ -92,13 +95,13 @@ function App(props: {}) {
 
           {programList.map(program => (
             //  @ts-ignore TODO: reach-router path fix
-            <ProgramStatic key={program} path={program} program={program} />
+            <Program key={program} path={program} program={program} />
           ))}
 
-          {/* @ts-ignore TODO: reach-router path fix */}
           {programs.map((program, index) => (
             <RegDashboard
               key={index}
+              // @ts-ignore TODO: reach-router path fix
               path={`${program.name}/${program.edition}/*`}
               program={program.name}
               edition={program.edition}

--- a/client/src/apiEndpoints.ts
+++ b/client/src/apiEndpoints.ts
@@ -1,3 +1,6 @@
+// Overall
+const programsEndpoint = "/programs/";
+
 // Accounts
 const loginEndpoint = "/token/";
 const tokenRefreshEndpoint = "/token/refresh/";
@@ -26,6 +29,7 @@ const studentAvailabilityEndpoint = "student/availability/";
 const studentScheduleEndpoint = "student/schedule/";
 
 export {
+  programsEndpoint,
   loginEndpoint,
   tokenRefreshEndpoint,
   userDataEndpoint,

--- a/client/src/registration/RegDashboard.tsx
+++ b/client/src/registration/RegDashboard.tsx
@@ -14,6 +14,7 @@ import { generalPage } from "../layout/Page";
 // import TeacherDashboard from "./TeacherRegDashboard";
 
 type Props = {
+  path?: string; // Typescript was complaining
   program: string;
   edition: string;
 };
@@ -65,9 +66,18 @@ function RegDashboard(props: Props) {
               edition={props.edition}
             />
             {/* @ts-ignore TODO: reach-router path fix */}
-            <StudentRegistration path="register" checks={regChecks} />
+            <StudentRegistration
+              path="register"
+              checks={regChecks}
+              program={props.program}
+              edition={props.edition}
+            />
             {/* @ts-ignore TODO: reach-router path fix */}
-            <ChangeClassesDashboard path="changeclasses" />
+            <ChangeClassesDashboard
+              path="changeclasses"
+              program={props.program}
+              edition={props.edition}
+            />
           </Router>
         )}
 

--- a/client/src/registration/RegDashboard.tsx
+++ b/client/src/registration/RegDashboard.tsx
@@ -14,7 +14,6 @@ import { generalPage } from "../layout/Page";
 // import TeacherDashboard from "./TeacherRegDashboard";
 
 type Props = {
-  path?: string; // Typescript was complaining
   program: string;
   edition: string;
 };
@@ -65,15 +64,15 @@ function RegDashboard(props: Props) {
               program={props.program}
               edition={props.edition}
             />
-            {/* @ts-ignore TODO: reach-router path fix */}
             <StudentRegistration
+              // @ts-ignore TODO: reach-router path fix
               path="register"
               checks={regChecks}
               program={props.program}
               edition={props.edition}
             />
-            {/* @ts-ignore TODO: reach-router path fix */}
             <ChangeClassesDashboard
+              // @ts-ignore TODO: reach-router path fix
               path="changeclasses"
               program={props.program}
               edition={props.edition}

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,0 +1,4 @@
+export type Program = {
+  name: string;
+  edition: string;
+};

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,4 +1,4 @@
-export type Program = {
+export type ProgramModel = {
   name: string;
   edition: string;
 };

--- a/server/core/urls.py
+++ b/server/core/urls.py
@@ -40,6 +40,7 @@ urlpatterns = [
             ]
         ),
     ),
+    path("api/programs/", views.get_all_programs),
     # auth API calls
     path("api/account/student/", views.StudentAccount.as_view()),
     path("api/token/", jwt_views.TokenObtainPairView.as_view(), name="token_obtain_pair"),

--- a/server/core/views/__init__.py
+++ b/server/core/views/__init__.py
@@ -1,5 +1,7 @@
 from core.models import Program
-from core.serializers import ClassSerializer
+from core.serializers import ClassSerializer, ProgramSerializer
+from rest_framework import permissions
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -8,6 +10,15 @@ from .dashboard import *  # noqa
 from .studentreg import *  # noqa
 
 # TODO figure out object permissions for all API calls
+
+
+@api_view(["GET"])
+@permission_classes(
+    [permissions.AllowAny,]
+)
+def get_all_programs(request):
+    programs = Program.objects.all()
+    return Response([ProgramSerializer(program).data for program in programs])
 
 
 class ClassCatalog(APIView):


### PR DESCRIPTION
Currently, the website allows you to go to any URL that is of the form `/[something]/[something2]` and it will treat it as a program. This means that people can try to go to `Splash 2040` or `Slosh 420` or `sijdfoiasd asoidfjaois` and our website will render it as a program. 

This PR pulls programs from the backend, to ensure that the only viable routes are the ones that are actually programs. 

Test:
* Went to all the different pages for an actual program, made sure they rendered correctly (with their API calls)
* Tried going to the page of a nonexistent program, verified that it showed up as `404 Not Found` 