### PR TITLE
Add isAdmin to auth for admin pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -37,6 +37,7 @@ function App(props: {}) {
     username: "",
     isStudent: false,
     isTeacher: false,
+    isAdmin: false,
   });
 
   const existingToken = localStorage.getItem("token") || "";
@@ -50,6 +51,7 @@ function App(props: {}) {
           username: result.data.username,
           isStudent: result.data.is_student,
           isTeacher: result.data.is_teacher,
+          isAdmin: result.data.is_admin,
         });
       });
     }

--- a/client/src/context/auth.tsx
+++ b/client/src/context/auth.tsx
@@ -6,6 +6,7 @@ export const AuthContext = createContext({
   username: "",
   isStudent: false,
   isTeacher: false,
+  isAdmin: false,
 });
 
 export function useAuth() {

--- a/server/core/models/users.py
+++ b/server/core/models/users.py
@@ -16,6 +16,11 @@ class ESPUser(AbstractUser):
         return hasattr(self, "teacher_profile")
 
     @property
+    def is_admin(self):
+        # TODO define what it means to be an admin
+        return self.is_superuser and self.is_staff
+
+    @property
     def profile(self):
         if self.is_student:
             return self.student_profile

--- a/server/core/serializers.py
+++ b/server/core/serializers.py
@@ -14,7 +14,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = ESPUser
-        fields = ("username", "is_student", "is_teacher")
+        fields = ("username", "is_student", "is_teacher", "is_admin")
 
 
 # TODO: The following two serializers are used for account creation and eventually should be fleshed


### PR DESCRIPTION
Pretty self-explanatory. Allows one to easily check if a user is an admin on the frontend.

Test:
* Went to a random page, printed out `isAdmin` from auth, made sure it was accurate. 